### PR TITLE
Recognizer reentrance; external TreeBuilder reuse

### DIFF
--- a/libmarpa-sys/build.rs
+++ b/libmarpa-sys/build.rs
@@ -58,7 +58,7 @@ where
 {
     let configure_status = Command::new(path.as_ref().join("configure"))
         .current_dir(&path)
-        .env("CFLAGS", "-fPIC")
+        .env("CFLAGS", "-fPIC -O3")
         .status()?;
     if !configure_status.success() {
         return Err(io::Error::new(io::ErrorKind::Other, "configure failed"));

--- a/marpa/src/parser/mod.rs
+++ b/marpa/src/parser/mod.rs
@@ -85,11 +85,13 @@ impl Parser {
 
     pub fn run_recognizer<T: TokenSource<U>, U: Token>(&mut self, tokens: T) -> Result<Tree> {
         let mut tokens = tokens;
-        match self.state {
-            MarpaState::G => self.adv_marpa()?,
-            MarpaState::GReady => self.adv_marpa()?,
-            _ => {}
-        };
+        loop {
+            // just prep the recognizer, irrespective of initial state
+            match self.state {
+                R(_) => break,
+                _ => self.adv_marpa()?,
+            }
+        }
         {
             // limit recognizer borrow
             let r = get_state!(self, R);

--- a/marpa/src/thin/tree.rs
+++ b/marpa/src/thin/tree.rs
@@ -53,7 +53,7 @@ impl Iterator for Tree {
         match unsafe { marpa_t_next(self.internal) } {
             -1 => None,
             i if i >= 0 => {
-                if let Ok(val) = Value::new(self.clone()) {
+                if let Ok(val) = Value::new(&self) {
                     Some(val)
                 } else {
                     None

--- a/marpa/src/thin/value.rs
+++ b/marpa/src/thin/value.rs
@@ -10,12 +10,14 @@ pub struct Value {
 }
 
 impl Value {
-    pub fn new(t: Tree) -> Result<Value> {
+    pub fn new(t: &Tree) -> Result<Value> {
         let t_internal = tree::internal(&t);
         let grammar = tree::grammar(&t);
-        match unsafe { marpa_v_new(t_internal) } {
-            n if n.is_null() => grammar.error_or("error creating value"),
-            v => Ok(Value { internal: v, grammar }),
+        let v = unsafe { marpa_v_new(t_internal) };
+        if v.is_null() {
+            grammar.error_or("error creating value") }
+        else {
+            Ok(Value { internal: v, grammar })
         }
     }
 }

--- a/marpa/src/tree_builder/builder.rs
+++ b/marpa/src/tree_builder/builder.rs
@@ -6,7 +6,7 @@ use crate::tree_builder::tree::Handle;
 use crate::tree_builder::tree::Node;
 use std::collections::HashSet;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TreeBuilder {
     token_rules: HashSet<Rule>,
     discard_rules: HashSet<Rule>,

--- a/marpa/src/tree_builder/builder.rs
+++ b/marpa/src/tree_builder/builder.rs
@@ -101,7 +101,7 @@ fn rollup_rule_rec(handles: &[Handle<ByteToken>], out: &mut Vec<Handle<ByteToken
             Node::Rule(_, _) => out.push(child.clone()),
             Node::Null(_) => {}
             Node::Tree(_, ref chs) => rollup_rule_rec(chs, out),
-            Node::Leaf(_) => panic!("cannot rollup Leaf into Rule - this is an internal bug."),
+            Node::Leaf(_) => {} //panic!("cannot rollup Leaf into Rule - this is an internal bug."),
         }
     }
 }

--- a/marpa/src/tree_builder/mod.rs
+++ b/marpa/src/tree_builder/mod.rs
@@ -1,5 +1,5 @@
-mod builder;
-mod tree;
+pub mod builder;
+pub mod tree;
 
 pub use self::builder::TreeBuilder;
-pub use self::tree::Handle;
+pub use self::tree::{Node, Handle};


### PR DESCRIPTION
@jrobsonchase  I am now trying to build my own minimal grammar interface, much more limited than the #2 SLIF parity I was hoping for. If it ends up looking useful and reusable, I'd be happy to offer that as a PR.

Before any of that, I'm trying to put all the pieces together and noticed that TreeBuilder needs a couple of modifications to be easily reused in external crates, which is in this PR.

---
Completely aside from that, I also need to figure out how to do the tree construction in parallel to the parsing process - I think the `proc_value` approach first obtains each parse, and then starts building? I'd like to prune some highly ambiguous parses during the construction phase, so the earlier I can hook into that the better.

A simpler question is how can I reuse the same parser to do multiple parses. Right now most methods end up consuming the various objects, while ideally they'd be `&mut self` signatures and one could keep reusing the same grammar+parser for a high volume of inputs.